### PR TITLE
Remove unused imports

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -2,8 +2,6 @@ use std::collections::HashMap;
 use std::iter::FromIterator;
 
 use byteorder::{ByteOrder, NetworkEndian};
-use crypto::digest::Digest;
-use crypto::sha3;
 use math::FE;
 use num::Zero;
 use rand::Rng;

--- a/rust/src/encrypt.rs
+++ b/rust/src/encrypt.rs
@@ -194,7 +194,7 @@ pub mod hybrid {
 mod tests {
     use super::hybrid::*;
     use super::*;
-    use crypto::curve25519::{curve25519, curve25519_base};
+    use crypto::curve25519::curve25519_base;
     use rand::os::OsRng;
 
     #[test]

--- a/rust/src/server.rs
+++ b/rust/src/server.rs
@@ -7,7 +7,6 @@ use data::*;
 use encrypt::hybrid::PrivcountDecryptor;
 use encrypt::Decryptor;
 use math::FE;
-use shamir;
 
 // The data a TR recovers from a single client
 pub struct ClientData {


### PR DESCRIPTION
This warning is spuious and disappears on nightly:
warning: field is never used: `client_key`

Closes 26946.